### PR TITLE
Small typo

### DIFF
--- a/content/docs/340-frameworks/300-solid.mdx
+++ b/content/docs/340-frameworks/300-solid.mdx
@@ -5,7 +5,7 @@ title: SolidJS
 ## Create a new site
 
 ```bash
-npm init capri my-capri-site -- -e solif
+npm init capri my-capri-site -- -e solid
 ```
 
 This will download and install [capri-js/capri/examples/solid](https://github.com/capri-js/capri/tree/main/examples/solid).


### PR DESCRIPTION
`- npm init capri my-capri-site -- -e solif`
`+ npm init capri my-capri-site -- -e solid`